### PR TITLE
Fix grading function

### DIFF
--- a/grade.py
+++ b/grade.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/grade.py
+++ b/grade.py
@@ -21,22 +21,7 @@ def score_to_grade(grade_number: float) -> str:
     for key in grading_scheme:
         if grade_number > grading_scheme[key]:
             grade = key
-    return grade
-
-
-def score_to_grade2(grade_number: float) -> str:
-    grading_scheme = {'A': 6,
-                      'B': 5,
-                      'C': 4,
-                      'D': 3,
-                      'E': 2,
-                      'F': 1}
-    grade = 'Invalid'
-    for key in grading_scheme:
-        if grade_number > grading_scheme[key]:
-            if grade == 'Invalid':
-                grade = key
-        print(grade, key, "grade, key")
+            break
     return grade
 
 


### PR DESCRIPTION
Previously, the grade would be wrong, for example
```
Number: 6.4990962170591144
Grade : F
```
while 6 and above should be an A.
This PR fixes this.